### PR TITLE
Fix missing mime types

### DIFF
--- a/lib/shrine/storage/azure_blob.rb
+++ b/lib/shrine/storage/azure_blob.rb
@@ -61,10 +61,10 @@ class Shrine
         )
         if (path = extract_path(io))
           ::File.open(path, 'rb') do |file|
-            client.create_block_blob(container_name, id, file.read, timeout: 30)
+            client.create_block_blob(container_name, id, file.read, timeout: 30, **_options)
           end
         else
-          client.create_block_blob(container_name, id, io.to_io)
+          client.create_block_blob(container_name, id, io.to_io, **_options)
         end
       end
 


### PR DESCRIPTION
the mime type that is determined in the `upload` method ans passed to put is not used in the actual call to `client.create_block_blob` therefor the `mime_type` is lost and every upload is created as default plain text which breaks everything that is not plain text in at least Firefox (Chrome seems to have a fallback auto-correction).